### PR TITLE
use more quotes, less echos, and more direct if

### DIFF
--- a/misc/get_puppetdb_certs.sh
+++ b/misc/get_puppetdb_certs.sh
@@ -13,15 +13,15 @@
 set -e
 
 usage() {
-    echo "./get_puppetdb_certs.sh <remote_username> <remote_sudo_password> <project>"
-    echo
-    echo "  Example: ./get_puppetdb_certs.sh john secret123 acme_inc"
+    cat << EOF
+    ./get_puppetdb_certs.sh <remote_username> <remote_sudo_password> <project>"
+    
+    Example: ./get_puppetdb_certs.sh john secret123 acme_inc"
+EOF
 }
 
 # Sanity checks
-which bolt > /dev/null 2>&1
-
-if [ $? -ne 0 ]; then
+if ! which bolt > /dev/null 2>&1; then
     echo "ERROR: this script requires Puppet Bolt ("bolt") to be in PATH to work!"
     exit 1
 fi
@@ -31,9 +31,9 @@ if [ "$1" = "" ] || [ "$2" = "" ] || [ "$3" = "" ]; then
     exit 1
 fi
 
-USERNAME=$1
-SUDO_PASSWORD=$2
-PROJECT=$3
+USERNAME="$1"
+SUDO_PASSWORD="$2"
+PROJECT="$3"
 CERTNAME="${USERNAME}_bolt"
 
 # We need to be in the project directory (=control repository root) for Bolt
@@ -45,20 +45,20 @@ WD=`pwd`
 # until PuppetDB certificates have been configured.
 mv inventory.yaml inventory.yaml.moved-temporarily
 
-bolt command run "/opt/puppetlabs/bin/puppetserver ca generate --certname ${CERTNAME}" -u $USERNAME -i static-inventory.yaml -t puppetmaster --run-as root --sudo-password $SUDO_PASSWORD
-bolt command run "tar -C /etc/puppetlabs/puppet/ssl -cf /home/${USERNAME}/puppetdb-certs.tar private_keys/${CERTNAME}.pem certs/${CERTNAME}.pem certs/ca.pem" -u $USERNAME -i static-inventory.yaml -t puppetmaster --run-as root --sudo-password $SUDO_PASSWORD
+bolt command run "/opt/puppetlabs/bin/puppetserver ca generate --certname ${CERTNAME}" -u "$USERNAME" -i static-inventory.yaml -t puppetmaster --run-as root --sudo-password "$SUDO_PASSWORD"
+bolt command run "tar -C /etc/puppetlabs/puppet/ssl -cf /home/${USERNAME}/puppetdb-certs.tar private_keys/${CERTNAME}.pem certs/${CERTNAME}.pem certs/ca.pem" -u "$USERNAME" -i static-inventory.yaml -t puppetmaster --run-as root --sudo-password "$SUDO_PASSWORD"
 
 mkdir -p ~/.puppetlabs/etc/bolt/openvpn/ssl
-bolt file download /home/$USERNAME/puppetdb-certs.tar ~/.puppetlabs/etc/bolt/$PROJECT/ssl -u $USERNAME -i static-inventory.yaml -t puppetmaster
+bolt file download "/home/$USERNAME/puppetdb-certs.tar" "~/.puppetlabs/etc/bolt/$PROJECT/ssl" -u "$USERNAME" -i static-inventory.yaml -t puppetmaster
 
-bolt command run "rm -f /home/$USERNAME/puppetdb-certs.tar" -u $USERNAME -i static-inventory.yaml -t puppetmaster --run-as root --sudo-password $SUDO_PASSWORD
+bolt command run "rm -f /home/$USERNAME/puppetdb-certs.tar" -u "$USERNAME" -i static-inventory.yaml -t puppetmaster --run-as root --sudo-password "$SUDO_PASSWORD"
 
-cd ~/.puppetlabs/etc/bolt/$PROJECT/ssl
+cd "~/.puppetlabs/etc/bolt/$PROJECT/ssl"
 tar -xf puppet*/puppetdb-certs.tar
 rm -rf puppet*
 cd certs
-mv $CERTNAME.pem cert.pem
+mv "$CERTNAME.pem" cert.pem
 cd ../private_keys
-mv $CERTNAME.pem key.pem
-cd $WD
+mv "$CERTNAME.pem" key.pem
+cd "$WD"
 mv inventory.yaml.moved-temporarily inventory.yaml

--- a/misc/get_puppetdb_certs.sh
+++ b/misc/get_puppetdb_certs.sh
@@ -49,11 +49,11 @@ bolt command run "/opt/puppetlabs/bin/puppetserver ca generate --certname ${CERT
 bolt command run "tar -C /etc/puppetlabs/puppet/ssl -cf /home/${USERNAME}/puppetdb-certs.tar private_keys/${CERTNAME}.pem certs/${CERTNAME}.pem certs/ca.pem" -u "$USERNAME" -i static-inventory.yaml -t puppetmaster --run-as root --sudo-password "$SUDO_PASSWORD"
 
 mkdir -p ~/.puppetlabs/etc/bolt/openvpn/ssl
-bolt file download "/home/$USERNAME/puppetdb-certs.tar" "~/.puppetlabs/etc/bolt/$PROJECT/ssl" -u "$USERNAME" -i static-inventory.yaml -t puppetmaster
+bolt file download "/home/$USERNAME/puppetdb-certs.tar" ~/.puppetlabs/etc/bolt/"$PROJECT"/ssl -u "$USERNAME" -i static-inventory.yaml -t puppetmaster
 
 bolt command run "rm -f /home/$USERNAME/puppetdb-certs.tar" -u "$USERNAME" -i static-inventory.yaml -t puppetmaster --run-as root --sudo-password "$SUDO_PASSWORD"
 
-cd "~/.puppetlabs/etc/bolt/$PROJECT/ssl"
+cd ~/.puppetlabs/etc/bolt/"$PROJECT"/ssl
 tar -xf puppet*/puppetdb-certs.tar
 rm -rf puppet*
 cd certs


### PR DESCRIPTION
*    shell is very picky about quotes. i added them everywhere a variable is used.

*    cat << EOF
    will let you output all the multi-line text desired without echo every line

*    no reason to run a command and then test its exit status, the if command already is made for testing exit status of commands, that is all it can actually do.

The quotes matter, the other 2 things are optional.